### PR TITLE
Added data for minibosses and player mons

### DIFF
--- a/include/constants/hunt_setup.h
+++ b/include/constants/hunt_setup.h
@@ -32,12 +32,6 @@ enum BossGroupList
     BOSS_PSEUDOS,
 };
 
-enum MiniBossList
-{
-    MINI_BOSS_LAPRAS,
-    MINI_BOSS_COUNT
-};
-
 //  MON_LIST_RANDOM must be last
 enum PlayerMonList
 {

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -496,6 +496,8 @@ struct SpeciesInfo /*0xC4*/
 #endif //OW_PKMN_OBJECTS_SHARE_PALETTES
 #endif //OW_POKEMON_OBJECT_EVENTS
     bool32 isPlayer;
+    u16 moveReward;
+    u16 abilityReward;
 };
 
 struct Ability

--- a/src/data/pokemon/species_info/gen_1_families.h
+++ b/src/data/pokemon/species_info/gen_1_families.h
@@ -1001,6 +1001,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sBlastoiseTeachableLearnset,
         .formSpeciesIdTable = sBlastoiseFormSpeciesIdTable,
         .formChangeTable = sBlastoiseFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_HYDRO_PUMP,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -1384,6 +1386,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sButterfreeTeachableLearnset,
         .formSpeciesIdTable = sButterfreeFormSpeciesIdTable,
         .formChangeTable = sButterfreeFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SLEEP_POWDER,
     },
 
 #if P_GIGANTAMAX_FORMS
@@ -2001,6 +2005,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sPidgeotTeachableLearnset,
         .formSpeciesIdTable = sPidgeotFormSpeciesIdTable,
         .formChangeTable = sPidgeotFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_FEATHER_DANCE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -2750,6 +2756,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sArbokLevelUpLearnset,
         .teachableLearnset = sArbokTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_COIL,
     },
 #endif //P_FAMILY_EKANS
 
@@ -2991,6 +2999,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .formChangeTable = sPikachuFormChangeTable,
         .evolutions = EVOLUTION({EVO_ITEM, ITEM_THUNDER_STONE, SPECIES_RAICHU},
                                 {EVO_NONE, 0, SPECIES_RAICHU_ALOLA}),
+        .maxPhases = 2,
+        .moveReward = MOVE_VOLT_TACKLE,
     },
 
 #if P_COSPLAY_PIKACHU_FORMS
@@ -4828,6 +4838,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sNidokingLevelUpLearnset,
         .teachableLearnset = sNidokingTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_EARTH_POWER,
     },
 #endif //P_FAMILY_NIDORAN
 
@@ -5901,6 +5913,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sCrobatLevelUpLearnset,
         .teachableLearnset = sCrobatTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_LEECH_LIFE,
     },
 #endif //P_GEN_2_CROSS_EVOS
 #endif //P_FAMILY_ZUBAT
@@ -6153,6 +6167,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sVileplumeLevelUpLearnset,
         .teachableLearnset = sVileplumeTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_MOONLIGHT,
     },
 
 #if P_GEN_2_CROSS_EVOS
@@ -6416,6 +6432,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sParasectLevelUpLearnset,
         .teachableLearnset = sParasectTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_GIGA_DRAIN,
     },
 #endif //P_FAMILY_PARAS
 
@@ -6590,6 +6608,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sVenomothLevelUpLearnset,
         .teachableLearnset = sVenomothTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_STRUGGLE_BUG,
     },
 #endif //P_FAMILY_VENONAT
 
@@ -6752,6 +6772,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .levelUpLearnset = sDugtrioLevelUpLearnset,
         .teachableLearnset = sDugtrioTeachableLearnset,
         .formSpeciesIdTable = sDugtrioFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_DIG,
     },
 
 #if P_ALOLAN_FORMS
@@ -7318,6 +7340,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sPerrserkerLevelUpLearnset,
         .teachableLearnset = sPerrserkerTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_METAL_SOUND,
     },
 #endif //P_GALARIAN_FORMS
 
@@ -7894,6 +7918,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .levelUpLearnset = sArcanineLevelUpLearnset,
         .teachableLearnset = sArcanineTeachableLearnset,
         .formSpeciesIdTable = sArcanineFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_FLARE_BLITZ,
     },
 
 #if P_HISUIAN_FORMS
@@ -8349,6 +8375,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sPolitoedLevelUpLearnset,
         .teachableLearnset = sPolitoedTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_GEN_2_CROSS_EVOS
 #endif //P_FAMILY_POLIWAG
@@ -8616,6 +8643,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sAlakazamTeachableLearnset,
         .formSpeciesIdTable = sAlakazamFormSpeciesIdTable,
         .formChangeTable = sAlakazamFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_PSYCHIC,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -9973,6 +10002,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .levelUpLearnset = sRapidashLevelUpLearnset,
         .teachableLearnset = sRapidashTeachableLearnset,
         .formSpeciesIdTable = sRapidashFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_AGILITY,
     },
 
 #if P_GALARIAN_FORMS
@@ -10255,6 +10286,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sSlowbroTeachableLearnset,
         .formSpeciesIdTable = sSlowbroFormSpeciesIdTable,
         .formChangeTable = sSlowbroFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_YAWN,
     },
 
 #if P_GEN_2_CROSS_EVOS
@@ -11393,6 +11426,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sDewgongLevelUpLearnset,
         .teachableLearnset = sDewgongTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ICE_BEAM,
     },
 #endif //P_FAMILY_SEEL
 
@@ -11838,6 +11873,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sCloysterLevelUpLearnset,
         .teachableLearnset = sCloysterTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ICICLE_SPEAR,
     },
 #endif //P_FAMILY_SHELLDER
 
@@ -12071,6 +12108,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sGengarTeachableLearnset,
         .formSpeciesIdTable = sGengarFormSpeciesIdTable,
         .formChangeTable = sGengarFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SHADOW_BALL,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -12362,6 +12401,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sSteelixTeachableLearnset,
         .formSpeciesIdTable = sSteelixFormSpeciesIdTable,
         .formChangeTable = sSteelixFormChangeTable,
+        .isPlayer = TRUE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -13265,6 +13305,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .levelUpLearnset = sExeggutorLevelUpLearnset,
         .teachableLearnset = sExeggutorTeachableLearnset,
         .formSpeciesIdTable = sExeggutorFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_ENERGY_BALL,
     },
 
 #if P_ALOLAN_FORMS
@@ -13485,6 +13527,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .levelUpLearnset = sMarowakLevelUpLearnset,
         .teachableLearnset = sMarowakTeachableLearnset,
         .formSpeciesIdTable = sMarowakFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_BONEMERANG
     },
 
 #if P_ALOLAN_FORMS
@@ -13549,6 +13593,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .levelUpLearnset = sMarowakAlolaLevelUpLearnset,
         .teachableLearnset = sMarowakAlolaTeachableLearnset,
         .formSpeciesIdTable = sMarowakFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SHADOW_BONE,
     },
 
     [SPECIES_MAROWAK_ALOLA_TOTEM] =
@@ -13766,6 +13812,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sHitmonleeLevelUpLearnset,
         .teachableLearnset = sHitmonleeTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_REVERSAL,
     },
 
     [SPECIES_HITMONCHAN] =
@@ -14230,6 +14278,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .levelUpLearnset = sWeezingLevelUpLearnset,
         .teachableLearnset = sWeezingTeachableLearnset,
         .formSpeciesIdTable = sWeezingFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_HAZE,
     },
 
 #if P_GALARIAN_FORMS
@@ -14560,6 +14610,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sRhyperiorLevelUpLearnset,
         .teachableLearnset = sRhyperiorTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ROCK_BLAST,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_RHYHORN
@@ -15327,6 +15379,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sKingdraLevelUpLearnset,
         .teachableLearnset = sKingdraTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_GEN_2_CROSS_EVOS
 #endif //P_FAMILY_HORSEA
@@ -15652,6 +15705,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sStarmieLevelUpLearnset,
         .teachableLearnset = sStarmieTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_POWER_GEM,
     },
 #endif //P_FAMILY_STARYU
 
@@ -15815,6 +15870,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sMrMimeTeachableLearnset,
         .eggMoveLearnset = sMrMimeEggMoveLearnset,
         .formSpeciesIdTable = sMrMimeFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_REFLECT,
     },
 
 #if P_GALARIAN_FORMS
@@ -15884,6 +15941,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .eggMoveLearnset = sMrMimeGalarEggMoveLearnset,
         .formSpeciesIdTable = sMrMimeFormSpeciesIdTable,
         .evolutions = EVOLUTION({EVO_LEVEL, 42, SPECIES_MR_RIME}),
+        .maxPhases = 2,
+        .moveReward = MOVE_LIGHT_SCREEN,
     },
 
     [SPECIES_MR_RIME] =
@@ -16043,6 +16102,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .evolutions = EVOLUTION({EVO_TRADE, 0, SPECIES_SCIZOR, CONDITIONS({IF_HOLD_ITEM, ITEM_METAL_COAT})},
                                 {EVO_ITEM, ITEM_BLACK_AUGURITE, SPECIES_KLEAVOR},
                                 {EVO_ITEM, ITEM_METAL_COAT, SPECIES_SCIZOR}),
+        .maxPhases = 2,
+        .moveReward = MOVE_U_TURN,
     },
 
 #if P_GEN_2_CROSS_EVOS
@@ -16129,6 +16190,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sScizorTeachableLearnset,
         .formSpeciesIdTable = sScizorFormSpeciesIdTable,
         .formChangeTable = sScizorFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_BULLET_PUNCH,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -16645,6 +16708,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sElectivireLevelUpLearnset,
         .teachableLearnset = sElectivireTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_PLASMA_FISTS,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_ELECTABUZZ
@@ -16869,6 +16934,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sMagmortarLevelUpLearnset,
         .teachableLearnset = sMagmortarTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_FLAMETHROWER,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_MAGMAR
@@ -17235,6 +17302,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .teachableLearnset = sTaurosPaldeaBlazeTeachableLearnset,
         .eggMoveLearnset = sTaurosPaldeaBlazeEggMoveLearnset,
         .formSpeciesIdTable = sTaurosFormSpeciesIdTable,
+        .isPlayer = TRUE,
     },
 
     [SPECIES_TAUROS_PALDEA_AQUA] =
@@ -17623,6 +17691,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .eggMoveLearnset = sLaprasEggMoveLearnset,
         .formSpeciesIdTable = sLaprasFormSpeciesIdTable,
         .formChangeTable = sLaprasFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_FREEZE_DRY,
     },
 
 #if P_GIGANTAMAX_FORMS
@@ -18060,6 +18130,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sVaporeonLevelUpLearnset,
         .teachableLearnset = sVaporeonTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BOUNCY_BUBBLE,
     },
 
     [SPECIES_JOLTEON] =
@@ -18127,6 +18199,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sJolteonLevelUpLearnset,
         .teachableLearnset = sJolteonTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_THUNDERBOLT,
     },
 
     [SPECIES_FLAREON] =
@@ -18263,6 +18337,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sEspeonLevelUpLearnset,
         .teachableLearnset = sEspeonTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_PSYCHIC_NOISE,
     },
 
     [SPECIES_UMBREON] =
@@ -18400,6 +18476,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sLeafeonLevelUpLearnset,
         .teachableLearnset = sLeafeonTeachableLearnset,
+        .isPlayer = TRUE,
     },
 
     [SPECIES_GLACEON] =
@@ -18468,6 +18545,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sGlaceonLevelUpLearnset,
         .teachableLearnset = sGlaceonTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_GEN_4_CROSS_EVOS
 
@@ -18926,6 +19004,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         )
         .levelUpLearnset = sOmastarLevelUpLearnset,
         .teachableLearnset = sOmastarTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_OMANYTE
 
@@ -19159,6 +19238,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .eggMoveLearnset = sAerodactylEggMoveLearnset,
         .formSpeciesIdTable = sAerodactylFormSpeciesIdTable,
         .formChangeTable = sAerodactylFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_STONE_EDGE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -19380,6 +19461,8 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .eggMoveLearnset = sSnorlaxEggMoveLearnset,
         .formSpeciesIdTable = sSnorlaxFormSpeciesIdTable,
         .formChangeTable = sSnorlaxFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SLACK_OFF,
     },
 
 #if P_GIGANTAMAX_FORMS

--- a/src/data/pokemon/species_info/gen_2_families.h
+++ b/src/data/pokemon/species_info/gen_2_families.h
@@ -225,6 +225,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sMeganiumLevelUpLearnset,
         .teachableLearnset = sMeganiumTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SYNTHESIS,
     },
 #endif //P_FAMILY_CHIKORITA
 
@@ -728,6 +730,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sFeraligatrLevelUpLearnset,
         .teachableLearnset = sFeraligatrTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_CHIP_AWAY,
     },
 #endif //P_FAMILY_TOTODILE
 
@@ -1479,6 +1483,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sLanturnLevelUpLearnset,
         .teachableLearnset = sLanturnTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_THUNDER_WAVE,
     },
 #endif //P_FAMILY_CHINCHOU
 
@@ -1859,6 +1865,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sXatuLevelUpLearnset,
         .teachableLearnset = sXatuTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_FUTURE_SIGHT,
     },
 #endif //P_FAMILY_NATU
 
@@ -2084,6 +2092,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .teachableLearnset = sAmpharosTeachableLearnset,
         .formSpeciesIdTable = sAmpharosFormSpeciesIdTable,
         .formChangeTable = sAmpharosFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_CHARGE_BEAM,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -2389,6 +2399,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sAzumarillLevelUpLearnset,
         .teachableLearnset = sAzumarillTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_PLAY_ROUGH,
     },
 #endif //P_FAMILY_MARILL
 
@@ -3100,6 +3112,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sSunfloraLevelUpLearnset,
         .teachableLearnset = sSunfloraTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_SUNKERN
 
@@ -3285,6 +3298,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sYanmegaLevelUpLearnset,
         .teachableLearnset = sYanmegaTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BUG_BUZZ,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_YANMA
@@ -3897,6 +3912,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sMismagiusLevelUpLearnset,
         .teachableLearnset = sMismagiusTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_HEX,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_MISDREAVUS
@@ -4304,6 +4321,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sFarigirafLevelUpLearnset,
         .teachableLearnset = sFarigirafTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ZEN_HEADBUTT,
     },
 #endif //P_GEN_9_CROSS_EVOS
 #endif //P_FAMILY_GIRAFARIG
@@ -5181,6 +5200,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sOverqwilLevelUpLearnset,
         .teachableLearnset = sOverqwilTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_HISUIAN_FORMS
 #endif //P_FAMILY_QWILFISH
@@ -5346,6 +5366,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .eggMoveLearnset = sHeracrossEggMoveLearnset,
         .formSpeciesIdTable = sHeracrossFormSpeciesIdTable,
         .formChangeTable = sHeracrossFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_MEGAHORN,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -5737,6 +5759,7 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sSneaslerLevelUpLearnset,
         .teachableLearnset = sSneaslerTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_HISUIAN_FORMS
 #endif //P_FAMILY_SNEASEL
@@ -5963,6 +5986,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .levelUpLearnset = sUrsalunaLevelUpLearnset,
         .teachableLearnset = sUrsalunaTeachableLearnset,
         .formSpeciesIdTable = sUrsalunaFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_HEADLONG_RUSH,
     },
 
     [SPECIES_URSALUNA_BLOODMOON] =
@@ -6416,6 +6441,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sMamoswineLevelUpLearnset,
         .teachableLearnset = sMamoswineTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ICE_SHARD,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_SWINUB
@@ -6633,6 +6660,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sCursolaLevelUpLearnset,
         .teachableLearnset = sCursolaTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BURNING_JEALOUSY,
     },
 #endif //P_GALARIAN_FORMS
 #endif //P_FAMILY_CORSOLA
@@ -7236,6 +7265,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         .teachableLearnset = sHoundoomTeachableLearnset,
         .formSpeciesIdTable = sHoundoomFormSpeciesIdTable,
         .formChangeTable = sHoundoomFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_DARK_PULSE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -7461,6 +7492,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sDonphanLevelUpLearnset,
         .teachableLearnset = sDonphanTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_EARTHQUAKE,
     },
 #endif //P_FAMILY_PHANPY
 
@@ -7600,6 +7633,8 @@ const struct SpeciesInfo gSpeciesInfoGen2[] =
         )
         .levelUpLearnset = sWyrdeerLevelUpLearnset,
         .teachableLearnset = sWyrdeerTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_PSYSHIELD_BASH,
     },
 #endif //P_GEN_8_CROSS_EVOS
 #endif //P_FAMILY_STANTLER

--- a/src/data/pokemon/species_info/gen_3_families.h
+++ b/src/data/pokemon/species_info/gen_3_families.h
@@ -218,6 +218,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .teachableLearnset = sSceptileTeachableLearnset,
         .formSpeciesIdTable = sSceptileFormSpeciesIdTable,
         .formChangeTable = sSceptileFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_LEAF_BLADE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -1229,6 +1231,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .levelUpLearnset = sLinooneLevelUpLearnset,
         .teachableLearnset = sLinooneTeachableLearnset,
         .formSpeciesIdTable = sLinooneFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_EXTREMESPEED,
     },
 
 #if P_GALARIAN_FORMS
@@ -2879,6 +2883,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .teachableLearnset = sGardevoirTeachableLearnset,
         .formSpeciesIdTable = sGardevoirFormSpeciesIdTable,
         .formChangeTable = sGardevoirFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_MOONBLAST,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -3800,6 +3806,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sNinjaskLevelUpLearnset,
         .teachableLearnset = sNinjaskTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BATON_PASS,
     },
 
     [SPECIES_SHEDINJA] =
@@ -4093,6 +4101,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sExploudLevelUpLearnset,
         .teachableLearnset = sExploudTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BOOMBURST,
     },
 #endif //P_FAMILY_WHISMUR
 
@@ -4240,6 +4250,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sHariyamaLevelUpLearnset,
         .teachableLearnset = sHariyamaTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ARM_THRUST,
     },
 #endif //P_FAMILY_MAKUHITA
 
@@ -4390,6 +4402,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sProbopassLevelUpLearnset,
         .teachableLearnset = sProbopassTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_GRAVITY,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_NOSEPASS
@@ -4779,6 +4793,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .eggMoveLearnset = sMawileEggMoveLearnset,
         .formSpeciesIdTable = sMawileFormSpeciesIdTable,
         .formChangeTable = sMawileFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_FOCUS_PUNCH,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -5072,6 +5088,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .teachableLearnset = sAggronTeachableLearnset,
         .formSpeciesIdTable = sAggronFormSpeciesIdTable,
         .formChangeTable = sAggronFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_IRON_HEAD,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -5831,6 +5849,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .levelUpLearnset = sVolbeatLevelUpLearnset,
         .teachableLearnset = sVolbeatTeachableLearnset,
         .eggMoveLearnset = sVolbeatEggMoveLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_TAIL_GLOW,
     },
 
     [SPECIES_ILLUMISE] =
@@ -6161,6 +6181,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sRoseradeLevelUpLearnset,
         .teachableLearnset = sRoseradeTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_LEAF_STORM,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_ROSELIA
@@ -6487,6 +6509,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .teachableLearnset = sSharpedoTeachableLearnset,
         .formSpeciesIdTable = sSharpedoFormSpeciesIdTable,
         .formChangeTable = sSharpedoFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_CRUNCH,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -7031,6 +7055,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .levelUpLearnset = sTorkoalLevelUpLearnset,
         .teachableLearnset = sTorkoalTeachableLearnset,
         .eggMoveLearnset = sTorkoalEggMoveLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_TORKOAL
 
@@ -7495,6 +7520,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sFlygonLevelUpLearnset,
         .teachableLearnset = sFlygonTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SAND_TOMB,
     },
 #endif //P_FAMILY_TRAPINCH
 
@@ -7806,6 +7833,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .teachableLearnset = sAltariaTeachableLearnset,
         .formSpeciesIdTable = sAltariaFormSpeciesIdTable,
         .formChangeTable = sAltariaFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_DRAGON_DANCE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -8110,6 +8139,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sLunatoneLevelUpLearnset,
         .teachableLearnset = sLunatoneTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_LUNATONE
 
@@ -8190,6 +8220,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sSolrockLevelUpLearnset,
         .teachableLearnset = sSolrockTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_SOLROCK
 
@@ -8357,6 +8388,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sWhiscashLevelUpLearnset,
         .teachableLearnset = sWhiscashTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_BARBOACH
 
@@ -8808,6 +8840,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sCradilyLevelUpLearnset,
         .teachableLearnset = sCradilyTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ANCIENT_POWER,
     },
 #endif //P_FAMILY_LILEEP
 
@@ -9134,6 +9168,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sMiloticLevelUpLearnset,
         .teachableLearnset = sMiloticTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_LIFE_DEW,
     },
 #endif //P_FAMILY_FEEBAS
 
@@ -9211,6 +9247,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .eggMoveLearnset = sCastformEggMoveLearnset,
         .formSpeciesIdTable = sCastformFormSpeciesIdTable,
         .formChangeTable = sCastformFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_WEATHER_BALL,
     },
 
     [SPECIES_CASTFORM_SUNNY] =
@@ -9288,6 +9326,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .eggMoveLearnset = sCastformEggMoveLearnset,
         .formSpeciesIdTable = sCastformFormSpeciesIdTable,
         .formChangeTable = sCastformFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_WEATHER_BALL,
     },
 
     [SPECIES_CASTFORM_RAINY] =
@@ -9363,6 +9403,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .eggMoveLearnset = sCastformEggMoveLearnset,
         .formSpeciesIdTable = sCastformFormSpeciesIdTable,
         .formChangeTable = sCastformFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_WEATHER_BALL,
     },
 
     [SPECIES_CASTFORM_SNOWY] =
@@ -9438,6 +9480,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .eggMoveLearnset = sCastformEggMoveLearnset,
         .formSpeciesIdTable = sCastformFormSpeciesIdTable,
         .formChangeTable = sCastformFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_WEATHER_BALL,
     },
 #endif //P_FAMILY_CASTFORM
 
@@ -9675,6 +9719,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .teachableLearnset = sBanetteTeachableLearnset,
         .formSpeciesIdTable = sBanetteFormSpeciesIdTable,
         .formChangeTable = sBanetteFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_PHANTOM_FORCE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -10069,6 +10115,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .levelUpLearnset = sTropiusLevelUpLearnset,
         .teachableLearnset = sTropiusTeachableLearnset,
         .eggMoveLearnset = sTropiusEggMoveLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_TROPIUS
 
@@ -10311,6 +10358,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .eggMoveLearnset = sAbsolEggMoveLearnset,
         .formSpeciesIdTable = sAbsolFormSpeciesIdTable,
         .formChangeTable = sAbsolFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_PUNISHMENT,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -10678,6 +10727,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sFroslassLevelUpLearnset,
         .teachableLearnset = sFroslassTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_GEN_4_CROSS_EVOS
 #endif //P_FAMILY_SNORUNT
@@ -10913,6 +10963,7 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         )
         .levelUpLearnset = sWalreinLevelUpLearnset,
         .teachableLearnset = sWalreinTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_SPHEAL
 
@@ -11292,6 +11343,8 @@ const struct SpeciesInfo gSpeciesInfoGen3[] =
         .levelUpLearnset = sLuvdiscLevelUpLearnset,
         .teachableLearnset = sLuvdiscTeachableLearnset,
         .eggMoveLearnset = sLuvdiscEggMoveLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SCALE_SHOT,
     },
 #endif //P_FAMILY_LUVDISC
 

--- a/src/data/pokemon/species_info/gen_4_families.h
+++ b/src/data/pokemon/species_info/gen_4_families.h
@@ -214,6 +214,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sTorterraLevelUpLearnset,
         .teachableLearnset = sTorterraTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_WOOD_HAMMER,
     },
 #endif //P_FAMILY_TURTWIG
 
@@ -436,6 +438,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sInfernapeLevelUpLearnset,
         .teachableLearnset = sInfernapeTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_CLOSE_COMBAT,
     },
 #endif //P_FAMILY_CHIMCHAR
 
@@ -666,6 +670,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sEmpoleonLevelUpLearnset,
         .teachableLearnset = sEmpoleonTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_PIPLUP
 
@@ -921,6 +926,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sStaraptorLevelUpLearnset,
         .teachableLearnset = sStaraptorTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BRAVE_BIRD,
     },
 #endif //P_FAMILY_STARLY
 
@@ -1663,6 +1670,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sRampardosLevelUpLearnset,
         .teachableLearnset = sRampardosTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_HEAD_SMASH,
     },
 #endif //P_FAMILY_CRANIDOS
 
@@ -2690,6 +2699,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sFloatzelLevelUpLearnset,
         .teachableLearnset = sFloatzelTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_WAVE_CRASH,
     },
 #endif //P_FAMILY_BUIZEL
 
@@ -2840,6 +2851,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .teachableLearnset = sCherrimTeachableLearnset,
         .formSpeciesIdTable = sCherrimFormSpeciesIdTable,
         .formChangeTable = sCherrimFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SOLAR_BEAM,
     },
 
     [SPECIES_CHERRIM_SUNSHINE] =
@@ -2904,6 +2917,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .teachableLearnset = sCherrimTeachableLearnset,
         .formSpeciesIdTable = sCherrimFormSpeciesIdTable,
         .formChangeTable = sCherrimFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SOLAR_BEAM,
     },
 #endif //P_FAMILY_CHERUBI
 
@@ -3102,6 +3117,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .levelUpLearnset = sGastrodonLevelUpLearnset,
         .teachableLearnset = sGastrodonTeachableLearnset,
         .formSpeciesIdTable = sGastrodonFormSpeciesIdTable,
+        .isPlayer = TRUE,
     },
 
     [SPECIES_GASTRODON_EAST] =
@@ -3166,6 +3182,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .levelUpLearnset = sGastrodonLevelUpLearnset,
         .teachableLearnset = sGastrodonTeachableLearnset,
         .formSpeciesIdTable = sGastrodonFormSpeciesIdTable,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_SHELLOS
 
@@ -3801,6 +3818,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sSkuntankLevelUpLearnset,
         .teachableLearnset = sSkuntankTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_GUNK_SHOT,
     },
 #endif //P_FAMILY_STUNKY
 
@@ -3952,6 +3971,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sBronzongLevelUpLearnset,
         .teachableLearnset = sBronzongTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_BRONZOR
 
@@ -4570,6 +4590,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .teachableLearnset = sLucarioTeachableLearnset,
         .formSpeciesIdTable = sLucarioFormSpeciesIdTable,
         .formChangeTable = sLucarioFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_AURA_SPHERE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -4965,6 +4987,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sDrapionLevelUpLearnset,
         .teachableLearnset = sDrapionTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_CROSS_POISON,
     },
 #endif //P_FAMILY_SKORUPI
 
@@ -5134,6 +5158,8 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         )
         .levelUpLearnset = sToxicroakLevelUpLearnset,
         .teachableLearnset = sToxicroakTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_FOCUS_BLAST,
     },
 #endif //P_FAMILY_CROAGUNK
 
@@ -5553,6 +5579,7 @@ const struct SpeciesInfo gSpeciesInfoGen4[] =
         .teachableLearnset = sAbomasnowTeachableLearnset,
         .formSpeciesIdTable = sAbomasnowFormSpeciesIdTable,
         .formChangeTable = sAbomasnowFormChangeTable,
+        .isPlayer = TRUE,
     },
 
 #if P_MEGA_EVOLUTIONS

--- a/src/data/pokemon/species_info/gen_5_families.h
+++ b/src/data/pokemon/species_info/gen_5_families.h
@@ -725,6 +725,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sSamurottLevelUpLearnset,
         .teachableLearnset = sSamurottTeachableLearnset,
         .formSpeciesIdTable = sSamurottFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_AQUA_CUTTER,
     },
 
 #if P_HISUIAN_FORMS
@@ -1292,6 +1294,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sLiepardLevelUpLearnset,
         .teachableLearnset = sLiepardTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_FOUL_PLAY,
     },
 #endif //P_FAMILY_PURRLOIN
 
@@ -1432,6 +1436,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sSimisageLevelUpLearnset,
         .teachableLearnset = sSimisageTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_JUNGLE_HEALING,
     },
 #endif //P_FAMILY_PANSAGE
 
@@ -2088,6 +2094,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sUnfezantLevelUpLearnset,
         .teachableLearnset = sUnfezantTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ROOST,
     },
 #endif //P_FAMILY_PIDOVE
 
@@ -2464,6 +2472,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sGigalithLevelUpLearnset,
         .teachableLearnset = sGigalithTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_ROGGENROLA
 
@@ -2623,6 +2632,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sSwoobatLevelUpLearnset,
         .teachableLearnset = sSwoobatTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_AIR_CUTTER,
     },
 #endif //P_FAMILY_WOOBAT
 
@@ -2841,6 +2852,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .eggMoveLearnset = sAudinoEggMoveLearnset,
         .formSpeciesIdTable = sAudinoFormSpeciesIdTable,
         .formChangeTable = sAudinoFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_HEAL_PULSE,
     },
 
 #if P_MEGA_EVOLUTIONS
@@ -3124,6 +3137,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sConkeldurrLevelUpLearnset,
         .teachableLearnset = sConkeldurrTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_DRAIN_PUNCH,
     },
 #endif //P_FAMILY_TIMBURR
 
@@ -4085,6 +4100,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sWhimsicottLevelUpLearnset,
         .teachableLearnset = sWhimsicottTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_TAILWIND,
     },
 #endif //P_FAMILY_COTTONEE
 
@@ -4572,6 +4589,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sBasculegionLevelUpLearnset,
         .teachableLearnset = sBasculegionTeachableLearnset,
         .formSpeciesIdTable = sBasculegionFormSpeciesIdTable,
+        .isPlayer = TRUE,
     },
 
     [SPECIES_BASCULEGION_F] =
@@ -4636,6 +4654,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sBasculegionLevelUpLearnset,
         .teachableLearnset = sBasculegionTeachableLearnset,
         .formSpeciesIdTable = sBasculegionFormSpeciesIdTable,
+        .isPlayer = TRUE,
     },
 #endif //P_HISUIAN_FORMS
 #endif //P_FAMILY_BASCULIN
@@ -4853,6 +4872,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sKrookodileLevelUpLearnset,
         .teachableLearnset = sKrookodileTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_POWER_TRIP,
     },
 #endif //P_FAMILY_SANDILE
 
@@ -5244,6 +5265,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .teachableLearnset = sDarmanitanGalarTeachableLearnset,
         .formSpeciesIdTable = sDarmanitanFormSpeciesIdTable,
         .formChangeTable = sDarmanitanGalarFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_ICE_BURN,
     },
 #endif //P_GALARIAN_FORMS
 #endif //P_FAMILY_DARUMAKA
@@ -5320,6 +5343,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sMaractusLevelUpLearnset,
         .teachableLearnset = sMaractusTeachableLearnset,
         .eggMoveLearnset = sMaractusEggMoveLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_MARACTUS
 
@@ -6603,6 +6627,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sZoroarkLevelUpLearnset,
         .teachableLearnset = sZoroarkTeachableLearnset,
         .formSpeciesIdTable = sZoroarkFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_NASTY_PLOT,
     },
 
 #if P_HISUIAN_FORMS
@@ -6877,6 +6903,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sCinccinoLevelUpLearnset,
         .teachableLearnset = sCinccinoTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_TAIL_SLAP,
     },
 #endif //P_FAMILY_MINCCINO
 
@@ -7313,6 +7341,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sReuniclusLevelUpLearnset,
         .teachableLearnset = sReuniclusTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_CALM_MIND,
     },
 #endif //P_FAMILY_SOLOSIS
 
@@ -7677,6 +7707,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sVanilluxeLevelUpLearnset,
         .teachableLearnset = sVanilluxeTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BLIZZARD,
     },
 #endif //P_FAMILY_VANILLITE
 
@@ -8409,6 +8441,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sEscavalierLevelUpLearnset,
         .teachableLearnset = sEscavalierTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_KARRABLAST
 
@@ -8951,6 +8984,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sGalvantulaLevelUpLearnset,
         .teachableLearnset = sGalvantulaTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ELECTROWEB,
     },
 #endif //P_FAMILY_JOLTIK
 
@@ -9906,6 +9941,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sChandelureLevelUpLearnset,
         .teachableLearnset = sChandelureTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_LITWICK
 
@@ -10111,6 +10147,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sHaxorusLevelUpLearnset,
         .teachableLearnset = sHaxorusTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_DRAGON_CLAW,
     },
 #endif //P_FAMILY_AXEW
 
@@ -10331,6 +10369,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sCryogonalLevelUpLearnset,
         .teachableLearnset = sCryogonalTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_RECOVER,
     },
 #endif //P_FAMILY_CRYOGONAL
 
@@ -10965,6 +11005,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sGolurkLevelUpLearnset,
         .teachableLearnset = sGolurkTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_FLY,
     },
 #endif //P_FAMILY_GOLETT
 
@@ -11173,6 +11215,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sKingambitLevelUpLearnset,
         .teachableLearnset = sKingambitTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SUCKER_PUNCH,
     },
 #endif //P_GEN_9_CROSS_EVOS
 #endif //P_FAMILY_PAWNIARD
@@ -11244,6 +11288,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sBouffalantLevelUpLearnset,
         .teachableLearnset = sBouffalantTeachableLearnset,
         .eggMoveLearnset = sBouffalantEggMoveLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_DOUBLE_EDGE,
     },
 #endif //P_FAMILY_BOUFFALANT
 
@@ -11452,6 +11498,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sBraviaryHisuiLevelUpLearnset,
         .teachableLearnset = sBraviaryHisuiTeachableLearnset,
         .formSpeciesIdTable = sBraviaryFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_ESPER_WING,
     },
 #endif //P_HISUIAN_FORMS
 #endif //P_FAMILY_RUFFLET
@@ -11591,6 +11639,7 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sMandibuzzLevelUpLearnset,
         .teachableLearnset = sMandibuzzTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_VULLABY
 
@@ -11660,6 +11709,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         .levelUpLearnset = sHeatmorLevelUpLearnset,
         .teachableLearnset = sHeatmorTeachableLearnset,
         .eggMoveLearnset = sHeatmorEggMoveLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_FIRE_LASH,
     },
 #endif //P_FAMILY_HEATMOR
 
@@ -12105,6 +12156,8 @@ const struct SpeciesInfo gSpeciesInfoGen5[] =
         )
         .levelUpLearnset = sVolcaronaLevelUpLearnset,
         .teachableLearnset = sVolcaronaTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_QUIVER_DANCE,
     },
 #endif //P_FAMILY_LARVESTA
 

--- a/src/data/pokemon/species_info/gen_6_families.h
+++ b/src/data/pokemon/species_info/gen_6_families.h
@@ -210,6 +210,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sChesnaughtLevelUpLearnset,
         .teachableLearnset = sChesnaughtTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_BODY_PRESS,
     },
 #endif //P_FAMILY_CHESPIN
 
@@ -424,6 +426,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sDelphoxLevelUpLearnset,
         .teachableLearnset = sDelphoxTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_MYSTICAL_FIRE,
     },
 #endif //P_FAMILY_FENNEKIN
 
@@ -1099,6 +1103,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sTalonflameLevelUpLearnset,
         .teachableLearnset = sTalonflameTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_FLETCHLING
 
@@ -1961,7 +1966,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )                                                                       \
         .levelUpLearnset = sFlorgesLevelUpLearnset,                             \
         .teachableLearnset = sFlorgesTeachableLearnset,                         \
-        .formSpeciesIdTable = sFlorgesFormSpeciesIdTable
+        .formSpeciesIdTable = sFlorgesFormSpeciesIdTable,                       \
+        .isPlayer = TRUE
 
     [SPECIES_FLORGES_RED] =
     {
@@ -2143,6 +2149,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sGogoatLevelUpLearnset,
         .teachableLearnset = sGogoatTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_TRAILBLAZE,
     },
 #endif //P_FAMILY_SKIDDO
 
@@ -2354,6 +2362,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .eggMoveLearnset = sFurfrouEggMoveLearnset,                                                     \
         .formSpeciesIdTable = sFurfrouFormSpeciesIdTable,                                               \
         .formChangeTable = sFurfrouFormChangeTable,                                                     \
+        .maxPhases = 2,                                                                                 \
+        .moveReward = MOVE_CHARM,                                                                       \
     }
 
     [SPECIES_FURFROU_NATURAL]   = FURFROU_MISC_INFO(Natural,   FALSE, 48, 3, 56, 0, 0),
@@ -2787,6 +2797,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .teachableLearnset = sAegislashTeachableLearnset,
         .formSpeciesIdTable = sAegislashFormSpeciesIdTable,
         .formChangeTable = sAegislashFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SWORDS_DANCE,
     },
 
     [SPECIES_AEGISLASH_BLADE] =
@@ -2856,6 +2868,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .teachableLearnset = sAegislashTeachableLearnset,
         .formSpeciesIdTable = sAegislashFormSpeciesIdTable,
         .formChangeTable = sAegislashFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SWORDS_DANCE,
     },
 #endif //P_FAMILY_HONEDGE
 
@@ -3284,6 +3298,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sMalamarLevelUpLearnset,
         .teachableLearnset = sMalamarTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_TOPSY_TURVY,
     },
 #endif //P_FAMILY_INKAY
 
@@ -3569,6 +3585,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sDragalgeLevelUpLearnset,
         .teachableLearnset = sDragalgeTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SLUDGE_BOMB,
     },
 #endif //P_FAMILY_SKRELP
 
@@ -3855,6 +3873,7 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sHelioliskLevelUpLearnset,
         .teachableLearnset = sHelioliskTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_HELIOPTILE
 
@@ -4137,6 +4156,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sAurorusLevelUpLearnset,
         .teachableLearnset = sAurorusTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_GLACIATE,
     },
 #endif //P_FAMILY_AMAURA
 
@@ -5263,6 +5284,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .levelUpLearnset = sGourgeistLevelUpLearnset,
         .teachableLearnset = sGourgeistTeachableLearnset,
         .formSpeciesIdTable = sGourgeistFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_TRICK_OR_TREAT,
     },
 
     [SPECIES_GOURGEIST_SMALL] =
@@ -5327,6 +5350,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .levelUpLearnset = sGourgeistLevelUpLearnset,
         .teachableLearnset = sGourgeistTeachableLearnset,
         .formSpeciesIdTable = sGourgeistFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_TRICK_OR_TREAT,
     },
 
     [SPECIES_GOURGEIST_LARGE] =
@@ -5391,6 +5416,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .levelUpLearnset = sGourgeistLevelUpLearnset,
         .teachableLearnset = sGourgeistTeachableLearnset,
         .formSpeciesIdTable = sGourgeistFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_TRICK_OR_TREAT,
     },
 
     [SPECIES_GOURGEIST_SUPER] =
@@ -5457,6 +5484,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         .levelUpLearnset = sGourgeistLevelUpLearnset,
         .teachableLearnset = sGourgeistTeachableLearnset,
         .formSpeciesIdTable = sGourgeistFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_TRICK_OR_TREAT,
     },
 #endif //P_FAMILY_PUMPKABOO
 
@@ -5823,6 +5852,8 @@ const struct SpeciesInfo gSpeciesInfoGen6[] =
         )
         .levelUpLearnset = sNoivernLevelUpLearnset,
         .teachableLearnset = sNoivernTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_DRACO_METEOR,
     },
 #endif //P_FAMILY_NOIBAT
 

--- a/src/data/pokemon/species_info/gen_7_families.h
+++ b/src/data/pokemon/species_info/gen_7_families.h
@@ -467,6 +467,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         )
         .levelUpLearnset = sIncineroarLevelUpLearnset,
         .teachableLearnset = sIncineroarTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_PARTING_SHOT,
     },
 #endif //P_FAMILY_LITTEN
 
@@ -1465,6 +1467,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         )
         .levelUpLearnset = sCrabominableLevelUpLearnset,
         .teachableLearnset = sCrabominableTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ICE_HAMMER,
     },
 #endif //P_FAMILY_CRABRAWLER
 
@@ -2819,6 +2823,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .levelUpLearnset = sAraquanidLevelUpLearnset,
         .teachableLearnset = sAraquanidTeachableLearnset,
         .formSpeciesIdTable = sAraquanidFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SOAK,
     },
 
     [SPECIES_ARAQUANID_TOTEM] =
@@ -3016,6 +3022,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .levelUpLearnset = sLurantisLevelUpLearnset,
         .teachableLearnset = sLurantisTeachableLearnset,
         .formSpeciesIdTable = sLurantisFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_SOLAR_BLADE,
     },
 
     [SPECIES_LURANTIS_TOTEM] =
@@ -3347,6 +3355,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .levelUpLearnset = sSalazzleLevelUpLearnset,
         .teachableLearnset = sSalazzleTeachableLearnset,
         .formSpeciesIdTable = sSalanditFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_TOXIC,
     },
 
     [SPECIES_SALAZZLE_TOTEM] =
@@ -3816,6 +3826,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .levelUpLearnset = sComfeyLevelUpLearnset,
         .teachableLearnset = sComfeyTeachableLearnset,
         .eggMoveLearnset = sComfeyEggMoveLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_DRAINING_KISS,
     },
 #endif //P_FAMILY_COMFEY
 
@@ -4224,6 +4236,7 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         )
         .levelUpLearnset = sPalossandLevelUpLearnset,
         .teachableLearnset = sPalossandTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_SANDYGAST
 
@@ -4477,7 +4490,9 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         FOOTPRINT(Minior)                                                   \
         .levelUpLearnset = sMiniorLevelUpLearnset,                          \
         .teachableLearnset = sMiniorTeachableLearnset,                      \
-        .formSpeciesIdTable = sMiniorFormSpeciesIdTable
+        .formSpeciesIdTable = sMiniorFormSpeciesIdTable,                    \
+        .maxPhases = 2,                                                     \
+        .moveReward = MOVE_METEOR_BEAM
 
 #define MINIOR_METEOR_SPECIES_INFO(Form)                    \
     {                                                       \
@@ -4698,6 +4713,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .levelUpLearnset = sTurtonatorLevelUpLearnset,
         .teachableLearnset = sTurtonatorTeachableLearnset,
         .eggMoveLearnset = sTurtonatorEggMoveLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SHELL_TRAP,
     },
 #endif //P_FAMILY_TURTONATOR
 
@@ -4762,6 +4779,8 @@ const struct SpeciesInfo gSpeciesInfoGen7[] =
         .teachableLearnset = sTogedemaruTeachableLearnset,
         .eggMoveLearnset = sTogedemaruEggMoveLearnset,
         .formSpeciesIdTable = sTogedemaruFormSpeciesIdTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_ZING_ZAP,
     },
 
     [SPECIES_TOGEDEMARU_TOTEM] =

--- a/src/data/pokemon/species_info/gen_8_families.h
+++ b/src/data/pokemon/species_info/gen_8_families.h
@@ -1109,6 +1109,8 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .teachableLearnset = sCorviknightTeachableLearnset,
         .formSpeciesIdTable = sCorviknightFormSpeciesIdTable,
         .formChangeTable = sCorviknightFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_IRON_DEFENSE,
     },
 
 #if P_GIGANTAMAX_FORMS
@@ -2339,6 +2341,8 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .teachableLearnset = sCoalossalTeachableLearnset,
         .formSpeciesIdTable = sCoalossalFormSpeciesIdTable,
         .formChangeTable = sCoalossalFormChangeTable,
+        .maxPhases = 2,
+        .moveReward = MOVE_TAR_SHOT,
     },
 
 #if P_GIGANTAMAX_FORMS
@@ -2842,6 +2846,8 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         )
         .levelUpLearnset = sHydrappleLevelUpLearnset,
         .teachableLearnset = sHydrappleTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SYRUP_BOMB,
     },
 #endif //P_GEN_9_CROSS_EVOS
 #endif //P_FAMILY_APPLIN
@@ -2974,6 +2980,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         .teachableLearnset = sSandacondaTeachableLearnset,
         .formSpeciesIdTable = sSandacondaFormSpeciesIdTable,
         .formChangeTable = sSandacondaFormChangeTable,
+        .isPlayer = TRUE,
     },
 
 #if P_GIGANTAMAX_FORMS
@@ -3344,6 +3351,8 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         )
         .levelUpLearnset = sBarraskewdaLevelUpLearnset,
         .teachableLearnset = sBarraskewdaTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_FLIP_TURN,
     },
 #endif //P_FAMILY_ARROKUDA
 
@@ -6140,6 +6149,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         )
         .levelUpLearnset = sDracozoltLevelUpLearnset,
         .teachableLearnset = sDracozoltTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_DRACOZOLT
 
@@ -6530,6 +6540,7 @@ const struct SpeciesInfo gSpeciesInfoGen8[] =
         )
         .levelUpLearnset = sArchaludonLevelUpLearnset,
         .teachableLearnset = sArchaludonTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_GEN_9_CROSS_EVOS
 #endif //P_FAMILY_DURALUDON

--- a/src/data/pokemon/species_info/gen_9_families.h
+++ b/src/data/pokemon/species_info/gen_9_families.h
@@ -388,6 +388,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sSkeledirgeLevelUpLearnset,
         .teachableLearnset = sSkeledirgeTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_WILL_O_WISP,
     },
 #endif //P_FAMILY_FUECOCO
 
@@ -907,6 +909,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sSpidopsLevelUpLearnset,
         .teachableLearnset = sSpidopsTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_SILK_TRAP,
     },
 #endif //P_FAMILY_TAROUNTULA
 
@@ -2206,6 +2210,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sGarganaclLevelUpLearnset,
         .teachableLearnset = sGarganaclTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_ROCK_POLISH,
     },
 #endif //P_FAMILY_NACLI
 
@@ -2531,6 +2537,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sBelliboltLevelUpLearnset,
         .teachableLearnset = sBelliboltTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_PARABOLIC_CHARGE,
     },
 #endif //P_FAMILY_TADBULB
 
@@ -2661,6 +2669,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sKilowattrelLevelUpLearnset,
         .teachableLearnset = sKilowattrelTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_WATTREL
 
@@ -3641,6 +3650,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sEspathraLevelUpLearnset,
         .teachableLearnset = sEspathraTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_STORED_POWER,
     },
 #endif //P_FAMILY_FLITTLE
 
@@ -4029,6 +4040,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .levelUpLearnset = sBombirdierLevelUpLearnset,
         .teachableLearnset = sBombirdierTeachableLearnset,
         .eggMoveLearnset = sBombirdierEggMoveLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_DUAL_WINGBEAT,
     },
 #endif //P_FAMILY_BOMBIRDIER
 
@@ -4749,6 +4762,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sHoundstoneLevelUpLearnset,
         .teachableLearnset = sHoundstoneTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_LAST_RESPECTS,
     },
 #endif //P_FAMILY_GREAVARD
 
@@ -5408,6 +5423,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .isParadox = TRUE,
         .levelUpLearnset = sScreamTailLevelUpLearnset,
         .teachableLearnset = sScreamTailTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_HYPER_VOICE,
     },
 #endif //P_FAMILY_SCREAM_TAIL
 
@@ -5678,6 +5695,7 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         .isParadox = TRUE,
         .levelUpLearnset = sSandyShocksLevelUpLearnset,
         .teachableLearnset = sSandyShocksTeachableLearnset,
+        .isPlayer = TRUE,
     },
 #endif //P_FAMILY_SANDY_SHOCKS
 
@@ -6462,6 +6480,8 @@ const struct SpeciesInfo gSpeciesInfoGen9[] =
         )
         .levelUpLearnset = sGholdengoLevelUpLearnset,
         .teachableLearnset = sGholdengoTeachableLearnset,
+        .maxPhases = 2,
+        .moveReward = MOVE_MAKE_IT_RAIN,
     },
 #endif //P_FAMILY_GIMMIGHOUL
 


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Adds `.isPlayer == TRUE` to all starter mons.
Adds phase count and reward to most minibosses.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara