### PR TITLE
Improved boss scripts

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2673,3 +2673,10 @@
 	.2byte \Y
 	.4byte \script
 	.endm
+
+	@ Buffer and object to remove at start of battle
+	.macro bufferremoveobject localId:req
+	callnative BufferRemoveObject
+	.2byte \localId
+	.endm
+

--- a/data/maps/Area1/scripts.pory
+++ b/data/maps/Area1/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area1_MapScripts {
 }
 
 script Area1_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area1_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area1_BossBattle {
 
 script Area1_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area1_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(1, 0)
     setflag(FLAG_AREA1_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area1_Miniboss1 {
 }
 
 script Area1_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(1, 1)
     setflag(FLAG_AREA1_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area1_Miniboss2 {
 }
 
 script Area1_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(1, 2)
     setflag(FLAG_AREA1_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area2/scripts.pory
+++ b/data/maps/Area2/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area2_MapScripts {
 }
 
 script Area2_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area2_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area2_BossBattle {
 
 script Area2_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area2_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(2, 0)
     setflag(FLAG_AREA2_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area2_Miniboss1 {
 }
 
 script Area2_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(2, 1)
     setflag(FLAG_AREA2_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area2_Miniboss2 {
 }
 
 script Area2_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(2, 2)
     setflag(FLAG_AREA2_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area3/scripts.pory
+++ b/data/maps/Area3/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area3_MapScripts {
 }
 
 script Area3_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area3_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area3_BossBattle {
 
 script Area3_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area3_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(3, 0)
     setflag(FLAG_AREA3_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area3_Miniboss1 {
 }
 
 script Area3_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(3, 1)
     setflag(FLAG_AREA3_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area3_Miniboss2 {
 }
 
 script Area3_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(3, 2)
     setflag(FLAG_AREA3_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area4/scripts.pory
+++ b/data/maps/Area4/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area4_MapScripts {
 }
 
 script Area4_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area4_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area4_BossBattle {
 
 script Area4_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area4_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(4, 0)
     setflag(FLAG_AREA4_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area4_Miniboss1 {
 }
 
 script Area4_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(4, 1)
     setflag(FLAG_AREA4_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area4_Miniboss2 {
 }
 
 script Area4_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(4, 2)
     setflag(FLAG_AREA4_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area5/scripts.pory
+++ b/data/maps/Area5/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area5_MapScripts {
 }
 
 script Area5_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area5_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area5_BossBattle {
 
 script Area5_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area5_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(5, 0)
     setflag(FLAG_AREA5_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area5_Miniboss1 {
 }
 
 script Area5_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(5, 1)
     setflag(FLAG_AREA5_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area5_Miniboss2 {
 }
 
 script Area5_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(5, 2)
     setflag(FLAG_AREA5_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area6/scripts.pory
+++ b/data/maps/Area6/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area6_MapScripts {
 }
 
 script Area6_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area6_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area6_BossBattle {
 
 script Area6_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area6_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(6, 0)
     setflag(FLAG_AREA6_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area6_Miniboss1 {
 }
 
 script Area6_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(6, 1)
     setflag(FLAG_AREA6_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area6_Miniboss2 {
 }
 
 script Area6_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(6, 2)
     setflag(FLAG_AREA6_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area7/scripts.pory
+++ b/data/maps/Area7/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area7_MapScripts {
 }
 
 script Area7_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area7_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area7_BossBattle {
 
 script Area7_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area7_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(7, 0)
     setflag(FLAG_AREA7_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area7_Miniboss1 {
 }
 
 script Area7_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(7, 1)
     setflag(FLAG_AREA7_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area7_Miniboss2 {
 }
 
 script Area7_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(7, 2)
     setflag(FLAG_AREA7_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area8/scripts.pory
+++ b/data/maps/Area8/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area8_MapScripts {
 }
 
 script Area8_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area8_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area8_BossBattle {
 
 script Area8_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area8_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(8, 0)
     setflag(FLAG_AREA8_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area8_Miniboss1 {
 }
 
 script Area8_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(8, 1)
     setflag(FLAG_AREA8_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area8_Miniboss2 {
 }
 
 script Area8_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(8, 2)
     setflag(FLAG_AREA8_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Area9/scripts.pory
+++ b/data/maps/Area9/scripts.pory
@@ -3,14 +3,26 @@ mapscripts Area9_MapScripts {
 }
 
 script Area9_BossBattle {
+    lock
+    faceplayer
     callnative(SetBossForBattle)
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     playmoncry(VAR_RESULT, CRY_MODE_NORMAL)
+    bufferremoveobject(LOCALID_BOSS)
     waitmoncry
     dowildbattle
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetAbilityReward)
+        msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+        waitmessage
+        setvar(VAR_0x8004, 0)  # vertical pan
+        setvar(VAR_0x8005, 2)  # horizontal pan
+        setvar(VAR_0x8006, 8)  # num shakes
+        setvar(VAR_0x8007, 3)  # shake delay
+        special(ShakeCamera)
+        waitstate
+        delay(40)
         warpcontinuescript(MAP_MYTH_HUB, 20, 18, Area9_AfterBossWarp)
     }
     release
@@ -18,20 +30,20 @@ script Area9_BossBattle {
 
 script Area9_AfterBossWarp {
     fadescreen(FADE_FROM_BLACK)
-    msgBox("You gained the power of {STR_VAR_3}!\nObtained {STR_VAR_2}!")
+    msgBox("The domain of {STR_VAR_3} collapsed.")
     release
 }
 
 script Area9_Miniboss1 {
-    lockall
+    lock
+    faceplayer
     setminiboss(9, 0)
     setflag(FLAG_AREA9_MINIBOSS1)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS1)
     waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS1)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -41,13 +53,15 @@ script Area9_Miniboss1 {
 }
 
 script Area9_Miniboss2 {
+    lock
+    faceplayer
     setminiboss(9, 1)
     setflag(FLAG_AREA9_MINIBOSS2)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS2)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS2)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)
@@ -57,13 +71,15 @@ script Area9_Miniboss2 {
 }
 
 script Area9_Miniboss3 {
+    lock
+    faceplayer
     setminiboss(9, 2)
     setflag(FLAG_AREA9_MINIBOSS3)
     playmoncry(VAR_RESULT, CRY_MODE_ENCOUNTER)
+    bufferremoveobject(LOCALID_MINIBOSS3)
+    waitmoncry
     setwildbattle(VAR_RESULT, BOSS_LEVEL, ITEM_NONE)
     dowildbattle
-    removeobject(LOCALID_MINIBOSS3)
-    fadescreen(FADE_FROM_BLACK)
     if (var(VAR_RESULT) != FALSE) {
         bufferspeciesname(STR_VAR_3, VAR_CURRENT_ENEMY)
         callnative(SetMoveReward)

--- a/data/maps/Boss/map.json
+++ b/data/maps/Boss/map.json
@@ -15,6 +15,7 @@
   "connections": null,
   "object_events": [
     {
+      "local_id": "LOCALID_FINAL_BOSS",
       "graphics_id": "OBJ_EVENT_GFX_SPECIES(FINAL_BOSS)",
       "x": 9,
       "y": 6,

--- a/data/maps/MythHub/scripts.pory
+++ b/data/maps/MythHub/scripts.pory
@@ -21,8 +21,11 @@ script MythHub_Area1 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA1, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area2 {
@@ -30,8 +33,11 @@ script MythHub_Area2 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA2, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area3 {
@@ -39,8 +45,11 @@ script MythHub_Area3 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA3, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area4 {
@@ -48,8 +57,11 @@ script MythHub_Area4 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA4, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area5 {
@@ -57,8 +69,11 @@ script MythHub_Area5 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA5, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area6 {
@@ -66,8 +81,11 @@ script MythHub_Area6 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA6, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area7 {
@@ -75,8 +93,11 @@ script MythHub_Area7 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA7, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area8 {
@@ -84,8 +105,11 @@ script MythHub_Area8 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA8, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 
 script MythHub_Area9 {
@@ -93,7 +117,10 @@ script MythHub_Area9 {
     waitstate
     if (var(VAR_RESULT) == TRUE) {
         warpsilent(MAP_AREA9, 10 , 10)
+    } else {
+        msgbox("The image of {STR_VAR_1} has faded.")
+        waitmessage
     }
-    end
+    release
 }
 

--- a/include/global.h
+++ b/include/global.h
@@ -1050,11 +1050,19 @@ struct HuntTargets
     u16 bosses[9];      //  Saved as enum BossGroupList
     u16 miniBosses[27]; //  Saved as species
     bool8 finalBossDefeated;
-    bool8 bossesDefeated[9];
+    u16 bossesDefeated[9];
     bool8 miniBossesDefeated[27];
     u8 currentArea;
     u16 currentBoss;
     u16 currentEnemy;
+};
+
+struct BufferedObjectRemoveStruct
+{
+    u8 localId;
+    u8 mapNum;
+    u8 mapGroup;
+    bool8 shouldRemove;
 };
 
 struct SaveBlock1
@@ -1175,6 +1183,7 @@ struct SaveBlock1
     u32 playerAffinity;
     u16 abilityStorage[9];
     u16 moveStorage[36];
+    struct BufferedObjectRemoveStruct bors;
 };
 
 extern struct SaveBlock1 *gSaveBlock1Ptr;

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -614,6 +614,7 @@ static void CB2_EndScriptedWildBattle(void)
 
     if (IsPlayerDefeated(gBattleOutcome) == TRUE)
     {
+        gSaveBlock1Ptr->bors.shouldRemove = FALSE;
         SetLossData();
         if (InBattlePyramid())
             SetMainCallback2(CB2_ReturnToFieldContinueScriptPlayMapMusic);

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -11534,3 +11534,11 @@ bool8 MovementAction_SurfStillRight_Step1(struct ObjectEvent *objectEvent, struc
     }
     return FALSE;
 }
+
+void BufferRemoveObject(struct ScriptContext *ctx)
+{
+    gSaveBlock1Ptr->bors.localId = ScriptReadHalfword(ctx);
+    gSaveBlock1Ptr->bors.mapNum = gSaveBlock1Ptr->location.mapNum;
+    gSaveBlock1Ptr->bors.mapGroup = gSaveBlock1Ptr->location.mapGroup;
+    gSaveBlock1Ptr->bors.shouldRemove = TRUE;
+}

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -154,9 +154,14 @@ static void Task_WaitForFadeAndEnableScriptCtx(u8 taskID)
 
 void FieldCB_ContinueScriptHandleMusic(void)
 {
+    if (gSaveBlock1Ptr->bors.shouldRemove)
+    {
+        RemoveObjectEventByLocalIdAndMap(gSaveBlock1Ptr->bors.localId, gSaveBlock1Ptr->bors.mapNum, gSaveBlock1Ptr->bors.mapGroup);
+        gSaveBlock1Ptr->bors.shouldRemove = FALSE;
+    }
     LockPlayerFieldControls();
     Overworld_PlaySpecialMapMusic();
-    //FadeInFromBlack();
+    FadeInFromBlack();
     CreateTask(Task_WaitForFadeAndEnableScriptCtx, 10);
 }
 

--- a/src/hunt_setup.c
+++ b/src/hunt_setup.c
@@ -266,9 +266,33 @@ struct BossSelect
 
 EWRAM_DATA struct BossSelect sBossSelect;
 
+void Task_ShortWait(u8 taskId)
+{
+    if (gTasks[taskId].data[0] == 0)
+    {
+        gTasks[taskId].data[0]++;
+    }
+    else
+    {
+        gSpecialVar_Result = FALSE;
+        DestroyTask(taskId);
+        ScriptContext_Enable();
+    }
+}
+
 void ChooseCurrentBossFromScript(struct ScriptContext *ctx)
 {
     u32 area = ScriptReadByte(ctx) - 1;
+
+    if (gSaveBlock1Ptr->huntTargets.bossesDefeated[area])
+    {
+        //  This is apparently needed
+        StringCopy(gStringVar1, gSpeciesInfo[gSaveBlock1Ptr->huntTargets.bossesDefeated[area]].speciesName);
+        u32 tempId = CreateTask(Task_ShortWait, 0);
+        gTasks[tempId].data[0] = 0;
+        return;
+    }
+
     sBossSelect.group = sBossGroups[gSaveBlock1Ptr->huntTargets.bosses[area]];
     gSaveBlock1Ptr->huntTargets.currentArea = area;
     sBossSelect.currIndex = 0;
@@ -451,10 +475,11 @@ void SetPostBattleData(void)
             }
         }
         break;
-    case 4: //  Boss
-        gSaveBlock1Ptr->huntTargets.bossesDefeated[gSaveBlock1Ptr->huntTargets.currentArea] = TRUE;
+    case 3: //  Boss
+        gSaveBlock1Ptr->huntTargets.bossesDefeated[gSaveBlock1Ptr->huntTargets.currentArea] = species;
+        MgbaPrintf(MGBA_LOG_WARN, "Value: %u", gSaveBlock1Ptr->huntTargets.bossesDefeated[0]);
         break;
-    case 5: //  Final Boss
+    case 4: //  Final Boss
         gSaveBlock1Ptr->huntTargets.finalBossDefeated = TRUE;
         SetWinData();
         break;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Changed how object events are removed after defeating them.
Added `bufferremoveobject`, which removes objects after battles before the the `fadescreen` is finished.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara