### PR TITLE
Add Zoroark disguise in overworld

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -1183,6 +1183,7 @@ struct SaveBlock1
     u32 playerAffinity;
     u16 abilityStorage[9];
     u16 moveStorage[36];
+    u16 zoroarkOverride;
     struct BufferedObjectRemoveStruct bors;
 };
 

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2112,6 +2112,10 @@ static u32 ConvertSpecies(u32 species)
             break;
         }
     }
+    if (species == SPECIES_ZOROARK)
+    {
+        species = gSaveBlock1Ptr->zoroarkOverride;
+    }
     return species;
 }
 

--- a/src/hunt_setup.c
+++ b/src/hunt_setup.c
@@ -154,6 +154,8 @@ void SetupHuntTargets(enum FinalBossList finalBoss)
         gSaveBlock1Ptr->huntTargets.miniBossesDefeated[i] = FALSE;
     }
 
+    gSaveBlock1Ptr->zoroarkOverride = shuffleList[27];
+
     //  Clear out saveblock data
     for (u32 i = 0; i < 36; i++)
         gSaveBlock1Ptr->moveStorage[i] = MOVE_NONE;


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Zoroark will disguise itself as another non-chosen mon from the current pool in the overworld.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara