### PR TITLE
Fix PP assignement on summary screen close

### DIFF
--- a/src/tarc_party_menu.c
+++ b/src/tarc_party_menu.c
@@ -1754,6 +1754,7 @@ static void TarcUi_WriteMonData(void)
             }
 
             SetMonData(&gPlayerParty[monIndex], MON_DATA_MOVE1 + targetIndex, &sTarcUiState->mons[monIndex].moves[moveIndex]);
+            SetMonData(&gPlayerParty[monIndex], MON_DATA_PP1 + targetIndex, &gMovesInfo[sTarcUiState->mons[monIndex].moves[moveIndex]].pp);
             targetIndex++;
         }
 


### PR DESCRIPTION
<!--- Provide a descriptive title that describes what was changed in this PR. --->

<!--- CONTRIBUTING.md : https://github.com/rh-hideout/pokeemerald-expansion/blob/master/CONTRIBUTING.md --->

<!--- Before submitting, ensure the following:--->

<!--- Code compiles without errors. --->
<!--- All functionality works as expected in-game. --->
<!--- No unexpected test failures. --->
<!--- New functionality is covered by tests if applicable. --->
<!--- Code follows the style guide. --->
<!--- No merge conflicts with the target branch. --->
<!--- If any of the above are not true, submit the PR as a draft. --->

## Description
<!-- Detail the changes made, why they were made, and any important context. -->
Fixed moves not getting any PP on the party summary screen.

## Discord contact info
<!-- Add your Discord username for any follow-up questions (e.g., pcg06). -->
<!-- If you have created a discussion thread, this is a good place to link it. -->
<!--- Contributors must join https://discord.gg/6CzjAG6GZk -->
hedara