### PR TITLE
Fix box-frame on Archives

### DIFF
--- a/data/maps/Entrance/scripts.pory
+++ b/data/maps/Entrance/scripts.pory
@@ -745,6 +745,7 @@ text Entrance_Text_Variations {
 script Entrance_Archive {
     lock
     msgbox("Welcome to the Archive.\nSelect a topic.")
+    setboxframe(BOX_FRAME_PC)
     dynmultichoice(0, 0, TRUE, 3, 0, DYN_MULTICHOICE_CB_NONE,
                     "Overflowing Abundance",
                     "The Lost Archipelago",


### PR DESCRIPTION
## Description
Opening an Archive didn't have an `setboxframe`, so the `dynmultichoice` was using the previous one, which could be anything.